### PR TITLE
feat: add support for nested remotes (crypt, alias, chunker, union)

### DIFF
--- a/deploy/example/minio-deploy.yaml
+++ b/deploy/example/minio-deploy.yaml
@@ -83,7 +83,6 @@ spec:
       protocol: TCP
       port: 9000
       targetPort: 9000
-      nodePort: 30900  # Accessible on any node at <node-ip>:30900
     - name: console
       protocol: TCP
       port: 9001

--- a/deploy/example/nested-remotes-example.yaml
+++ b/deploy/example/nested-remotes-example.yaml
@@ -1,0 +1,188 @@
+---
+# Example: Using Nested Remotes (Crypt, Alias, Chunker, Union)
+# This demonstrates the fix for issue #15 - nested remotes support
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-nested-remotes-secret
+  namespace: default
+type: Opaque
+stringData:
+  # Full rclone configuration with nested remotes
+  # The CSI driver will load ALL sections and let rclone resolve the chain
+  configData: |
+    ########################################
+    # Base MinIO Remote (S3-compatible)
+    ########################################
+    [minio-sample]
+    type = s3
+    provider = Minio
+    endpoint = http://minio.default.svc.cluster.local:9000
+    access_key_id = admin
+    secret_access_key = password
+    region = us-east-1
+    acl = private
+
+    ########################################
+    # Alias layer (prevents nested remote bug)
+    # Points to /encrypted path on base remote
+    ########################################
+    [minio-encrypted-base]
+    type = alias
+    remote = minio-sample:/encrypted
+
+    ########################################
+    # Crypt Remote (encryption layer)
+    # Encrypts files and directories
+    ########################################
+    [minio-sample-crypt]
+    type = crypt
+    remote = minio-encrypted-base:
+    filename_encryption = standard
+    directory_name_encryption = true
+    # Generate with: rclone obscure <password>
+    password = xK8eIuJdPQmcQiq5G5u2IQ
+    password2 = bM7zjvZfBbFvx3zO7S9KOA
+
+    ########################################
+    # Chunker Remote (splits large files)
+    ########################################
+    [minio-sample-chunker]
+    type = chunker
+    remote = minio-sample-crypt:
+    chunk_size = 128Mi
+
+    ########################################
+    # Union Remote (combines multiple sources)
+    ########################################
+    [minio-union]
+    type = union
+    upstreams = minio-sample-chunker: minio-sample-crypt:
+    create_policy = epff
+    search_policy = ff
+    action_policy = epff
+
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-minio-crypt
+spec:
+  accessModes:
+  - ReadWriteMany
+  capacity:
+    storage: 10Gi
+  storageClassName: rclone
+  csi:
+    driver: rclone.csi.veloxpack.io
+    volumeHandle: minio-crypt-volume
+    volumeAttributes:
+      # Use the crypt remote name directly
+      # The CSI driver will resolve: minio-sample-crypt -> minio-encrypted-base -> minio-sample
+      remote: "minio-sample-crypt"
+      remotePath: "data"
+    nodePublishSecretRef:
+      name: minio-nested-remotes-secret
+      namespace: default
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-minio-crypt
+  namespace: default
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: rclone
+  volumeName: pv-minio-crypt
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-minio-crypt
+  namespace: default
+spec:
+  containers:
+  - name: test
+    image: busybox
+    command:
+    - sleep
+    - "3600"
+    volumeMounts:
+    - name: encrypted-storage
+      mountPath: /data
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "100m"
+  volumes:
+  - name: encrypted-storage
+    persistentVolumeClaim:
+      claimName: pvc-minio-crypt
+
+---
+# Example 2: Using Chunker Remote
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-minio-chunker
+spec:
+  accessModes:
+  - ReadWriteMany
+  capacity:
+    storage: 10Gi
+  storageClassName: rclone
+  csi:
+    driver: rclone.csi.veloxpack.io
+    volumeHandle: minio-chunker-volume
+    volumeAttributes:
+      # Use the chunker remote which wraps crypt which wraps alias which wraps s3
+      # Full chain: minio-sample-chunker -> minio-sample-crypt -> minio-encrypted-base -> minio-sample
+      remote: "minio-sample-chunker"
+      remotePath: "large-files"
+    nodePublishSecretRef:
+      name: minio-nested-remotes-secret
+      namespace: default
+
+---
+# Example 3: Using Union Remote
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-minio-union
+spec:
+  accessModes:
+  - ReadWriteMany
+  capacity:
+    storage: 20Gi
+  storageClassName: rclone
+  csi:
+    driver: rclone.csi.veloxpack.io
+    volumeHandle: minio-union-volume
+    volumeAttributes:
+      # Use the union remote that combines multiple encrypted sources
+      remote: "minio-union"
+      remotePath: ""
+    nodePublishSecretRef:
+      name: minio-nested-remotes-secret
+      namespace: default
+
+# Testing Notes:
+# 1. Deploy the secret with configData containing all remote definitions
+# 2. The CSI driver will load ALL config sections into in-memory storage
+# 3. When you reference "minio-sample-crypt", rclone will automatically:
+#    - Look up minio-sample-crypt -> type=crypt, remote=minio-encrypted-base:
+#    - Look up minio-encrypted-base -> type=alias, remote=minio-sample:/encrypted
+#    - Look up minio-sample -> type=s3, connect to MinIO
+# 4. Files written to /data in the pod will be encrypted transparently
+# Example test:
+  # kubectl apply -f nested-remotes-example.yaml
+  # kubectl exec -it test-minio-crypt -- sh -c 'echo "Hello, MinIO encrypted storage!" > /data/hello.txt'
+  # kubectl exec test-minio-crypt -- cat /data/hello.txt
+  # kubectl delete -f nested-remotes-example.yaml

--- a/deploy/example/rclone-pv-example.yaml
+++ b/deploy/example/rclone-pv-example.yaml
@@ -27,7 +27,7 @@ spec:
         [s3]
         type = s3
         provider = Minio
-        endpoint = http://localhost:30900
+        endpoint = http://minio.default.svc.cluster.local:9000
         access_key_id = admin
         secret_access_key = password
 ---

--- a/deploy/example/rclone-secret.yaml
+++ b/deploy/example/rclone-secret.yaml
@@ -14,7 +14,7 @@ stringData:
     [s3]
     type = s3
     provider = Minio
-    endpoint = http://localhost:30900
+    endpoint = http://minio.default.svc.cluster.local:9000
     access_key_id = admin
     secret_access_key = password
 ---

--- a/pkg/rclone/nodeserver_test.go
+++ b/pkg/rclone/nodeserver_test.go
@@ -233,51 +233,6 @@ func TestSanitizeRemoteName(t *testing.T) {
 	}
 }
 
-func TestParseConfigData(t *testing.T) {
-	tests := []struct {
-		desc       string
-		configData string
-		remoteName string
-		expectErr  bool
-	}{
-		{
-			desc: "Valid INI config",
-			configData: `[s3]
-type = s3
-provider = AWS
-access_key_id = test`,
-			remoteName: "s3",
-			expectErr:  false,
-		},
-		{
-			desc:       "Invalid INI format",
-			configData: "not valid ini",
-			remoteName: "s3",
-			expectErr:  true,
-		},
-		{
-			desc: "Remote not found",
-			configData: `[s3]
-type = s3`,
-			remoteName: "gcs",
-			expectErr:  true,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.desc, func(t *testing.T) {
-			result, err := parseConfigData(test.configData, test.remoteName)
-
-			if test.expectErr {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-				assert.NotNil(t, result)
-			}
-		})
-	}
-}
-
 func TestUnimplementedNodeMethods(t *testing.T) {
 	ns, err := getTestNodeServer()
 	assert.NoError(t, err)


### PR DESCRIPTION
This commit implements full support for nested remote configurations, resolving issue #15 where the driver incorrectly interpreted remote names as backend types.

Key Changes:
- Added parseAllConfigSections() to parse complete rclone INI configs
- Modified NodePublishVolume() to load all config sections into memory
- Updated mountContext struct to track loaded sections for cleanup
- Enhanced NodeUnpublishVolume() to clean up all loaded config sections
- Removed obsolete parseConfigData() function

Technical Implementation:
The driver now loads ALL config sections from configData into rclone's in-memory storage (config.LoadedData()), enabling automatic nested remote resolution through rclone's native fs.NewFs() mechanism.

When a user mounts a remote like "minio-crypt:", rclone automatically resolves the chain:
  minio-crypt (crypt) -> minio-alias (alias) -> minio-base (s3)

Benefits:
- Supports client-side encryption (GDPR, HIPAA, PCI-DSS compliance)
- Enables complex remote chains (union, chunker, compress, cache)
- All operations remain in-memory only (no disk writes)
- Full backwards compatibility with existing configurations
- Thread-safe with mutex protection

Breaking Changes: None
- Existing deployments continue to work without modifications
- Legacy config.CreateRemote() path preserved for backwards compatibility

Security:
- No config disk writes - all config stays in memory
- Enables encryption at rest with crypt remotes

Fixes #15
