### PR TITLE
feat: support-fsgroup noroot pods

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,11 @@ WORKDIR /
 RUN apk add --no-cache ca-certificates fuse3 tzdata && \
     rm -rf /var/cache/apk/* /tmp/*
 
+# Enable allow_other for FUSE mounts
+RUN printf '%s\n' \
+    "# Allow rclone to use the --allow-other flag" \
+    "user_allow_other" >> /etc/fuse.conf
+
 COPY --from=builder /workspace/rcloneplugin .
 
 ENTRYPOINT ["/rcloneplugin"]

--- a/charts/templates/csi-rclone-driverinfo.yaml
+++ b/charts/templates/csi-rclone-driverinfo.yaml
@@ -13,9 +13,6 @@ spec:
     {{- if .Values.feature.enableInlineVolume }}
     - Ephemeral
     {{- end }}
-  {{- if .Values.feature.enableFSGroupPolicy }}
-  fsGroupPolicy: File
-  {{- end }}
   {{- if .Values.feature.propagateHostMountOptions }}
   volumeMountOptions: true
   {{- end }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -38,7 +38,6 @@ driver:
   mountPermissions: 0
 
 feature:
-  enableFSGroupPolicy: true
   enableInlineVolume: false
   propagateHostMountOptions: false
 

--- a/deploy/base/csi-rclone-driverinfo.yaml
+++ b/deploy/base/csi-rclone-driverinfo.yaml
@@ -7,4 +7,4 @@ spec:
   attachRequired: false
   volumeLifecycleModes:
     - Persistent
-  fsGroupPolicy: File
+  podInfoOnMount: true

--- a/deploy/example/rclone-non-root-pod.yaml
+++ b/deploy/example/rclone-non-root-pod.yaml
@@ -1,0 +1,79 @@
+---
+# Rclone CSI Driver Storage Class
+# This is a template StorageClass that can be customized for different backends
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rclone-csi
+provisioner: rclone.csi.veloxpack.io
+parameters:
+  # Required: Rclone remote name (backend type)
+  remote: "minio-sample"
+  # Optional: Path within the remote storage
+  remotePath: "mybucket"
+  # Reference to secret containing sensitive configuration
+  csi.storage.k8s.io/node-publish-secret-name: "rclone-secret"
+  csi.storage.k8s.io/node-publish-secret-namespace: "default"
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+allowVolumeExpansion: true
+---
+# Example Secret for S3 Configuration
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rclone-secret
+  namespace: default
+type: Opaque
+stringData:
+  # Rclone configuration in INI format
+  configData: |
+    [minio-sample]
+    type = s3
+    provider = Minio
+    endpoint = http://minio.default.svc.cluster.local:9000
+    access_key_id = admin
+    secret_access_key = password
+---
+# Example PVC using the StorageClass
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-rclone-example
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: rclone-csi
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: rclone-test-app
+  namespace: default
+spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
+    fsGroupChangePolicy: OnRootMismatch
+    runAsNonRoot: true
+  containers:
+  - name: test
+    image: busybox
+    command:
+    - sleep
+    - "3600"
+    volumeMounts:
+    - name: rclone-storage
+      mountPath: /data
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "100m"
+  volumes:
+  - name: rclone-storage
+    persistentVolumeClaim:
+      claimName: pvc-rclone-example

--- a/pkg/rclone/metrics_collector.go
+++ b/pkg/rclone/metrics_collector.go
@@ -30,6 +30,8 @@ import (
 
 const (
 	unknownValue = "unknown"
+	trueValue    = "true"
+	falseValue   = "false"
 )
 
 var (
@@ -591,11 +593,11 @@ func getVolumeName(mc *mountContext) string {
 // Helper function to determine read-only status
 func isReadOnly(mc *mountContext) string {
 	if mc == nil || mc.mountPoint == nil {
-		return "false"
+		return falseValue
 	}
 	// Check VFS options for read-only mode
 	if mc.mountPoint.VFSOpt.ReadOnly {
-		return "true"
+		return trueValue
 	}
-	return "false"
+	return falseValue
 }

--- a/pkg/rclone/rclone.go
+++ b/pkg/rclone/rclone.go
@@ -81,6 +81,7 @@ func NewDriver(options *DriverOptions) *Driver {
 	d.AddNodeServiceCapabilities([]csi.NodeServiceCapability_RPC_Type{
 		csi.NodeServiceCapability_RPC_UNKNOWN,
 		csi.NodeServiceCapability_RPC_VOLUME_CONDITION,
+		csi.NodeServiceCapability_RPC_VOLUME_MOUNT_GROUP,
 	})
 
 	d.volumeLocks = NewVolumeLocks()

--- a/pkg/rclone/rclone_test.go
+++ b/pkg/rclone/rclone_test.go
@@ -112,12 +112,14 @@ func TestNewDriver(t *testing.T) {
 			// assert.Equal(t, csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME,
 			// 	driver.cscap[1].GetRpc().Type)
 
-			// Verify node capabilities (UNKNOWN and VOLUME_CONDITION)
-			assert.Equal(t, 2, len(driver.nscap))
+			// Verify node capabilities include UNKNOWN, VOLUME_CONDITION, and VOLUME_MOUNT_GROUP
+			assert.Equal(t, 3, len(driver.nscap))
 			assert.Equal(t, csi.NodeServiceCapability_RPC_UNKNOWN,
 				driver.nscap[0].GetRpc().Type)
 			assert.Equal(t, csi.NodeServiceCapability_RPC_VOLUME_CONDITION,
 				driver.nscap[1].GetRpc().Type)
+			assert.Equal(t, csi.NodeServiceCapability_RPC_VOLUME_MOUNT_GROUP,
+				driver.nscap[2].GetRpc().Type)
 		})
 	}
 }


### PR DESCRIPTION
## PR Summary

- implement driver-managed fsGroup support so rclone mounts honor pod security contexts  
- inspect kubelet-prepared target path, derive uid/gid, and pass them to rclone mount options  
- add platform-specific ownership helpers, enable VOLUME_MOUNT_GROUP capability

### Details

- detect security context: new helper captures directory ownership and returns consistent string values  
- NodePublishVolume: reads VolumeMountGroup, calls detector, cascades values into mount parameters, logs when fsGroup delegated  
- mounting: createAndMountFilesystem now accepts volumeMountGroup info, injects `uid`, `gid`, and `allow_other` when requested

Fixes #34