### PR TITLE
feat: add separate cache folder mount support

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,48 +415,15 @@ spec:
 
 ### Separate Cache Directory Mount
 
-For improved performance, you can mount a separate volume for the rclone cache directory. This is especially useful for:
-- Using faster storage for cache (e.g., local SSD, NVMe)
-- Mounting host paths in Talos/PVE environments
-- Using CSI volumes for cache storage
-
-**Option 1: Host Path Mount (for Talos/PVE)**
+For improved performance, you can mount a separate host path for the rclone cache directory. This is especially useful for:
+- Using faster local storage for cache (e.g., SSD, NVMe)
+- Mounting dedicated disks
 
 ```bash
 helm upgrade --install csi-rclone oci://ghcr.io/veloxpack/charts/csi-driver-rclone \
   --namespace veloxpack --create-namespace \
   --set node.cache.enabled=true \
-  --set node.cache.type=hostPath \
   --set node.cache.hostPath=/mnt/rclone-cache
-```
-
-**Option 2: PVC Mount (for faster storage)**
-
-First, create a PVC for the cache:
-
-```yaml
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: rclone-cache-pvc
-  namespace: veloxpack
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 100Gi
-  storageClassName: fast-ssd  # Use your fast storage class
-```
-
-Then install with cache PVC:
-
-```bash
-helm upgrade --install csi-rclone oci://ghcr.io/veloxpack/charts/csi-driver-rclone \
-  --namespace veloxpack --create-namespace \
-  --set node.cache.enabled=true \
-  --set node.cache.type=pvc \
-  --set node.cache.pvcName=rclone-cache-pvc
 ```
 
 **Using the Cache Directory**
@@ -489,9 +456,7 @@ spec:
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `node.cache.enabled` | Enable cache volume mount | `false` |
-| `node.cache.type` | Volume type: `hostPath` or `pvc` | `hostPath` |
-| `node.cache.hostPath` | Host path (required if type is `hostPath`) | `""` |
-| `node.cache.pvcName` | PVC name (required if type is `pvc`) | `""` |
+| `node.cache.hostPath` | Host path (required when enabled) | `""` |
 | `node.cache.mountPath` | Mount path in container | `/var/lib/rclone-cache` |
 
 ## Troubleshooting

--- a/charts/templates/csi-rclone-node.yaml
+++ b/charts/templates/csi-rclone-node.yaml
@@ -162,12 +162,7 @@ spec:
             type: DirectoryOrCreate
         {{- if .Values.node.cache.enabled }}
         - name: rclone-cache
-          {{- if eq .Values.node.cache.type "hostPath" }}
           hostPath:
             path: {{ .Values.node.cache.hostPath }}
             type: DirectoryOrCreate
-          {{- else if eq .Values.node.cache.type "pvc" }}
-          persistentVolumeClaim:
-            claimName: {{ .Values.node.cache.pvcName }}
-          {{- end }}
         {{- end }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -193,15 +193,12 @@ node:
   extraArgs: {}
 
   # Cache directory mount configuration
-  # This allows mounting a separate volume for rclone cache directory, useful for:
-  # - Using faster storage for cache (e.g., local SSD, NVMe)
-  # - Mounting host paths in Talos/PVE environments
-  # - Using CSI volumes for cache storage
+  # This allows mounting a host path for the rclone cache directory, useful for:
+  # - Using faster local storage for cache (e.g., SSD, NVMe)
+  # - Mounting dedicated disks
   cache:
     enabled: false
-    type: hostPath  # Options: "hostPath" or "pvc"
-    hostPath: ""  # Required if type is "hostPath" (e.g., "/mnt/rclone-cache")
-    pvcName: ""  # Required if type is "pvc" (e.g., "rclone-cache-pvc")
+    hostPath: ""  # Required when enabled (e.g., "/mnt/rclone-cache")
     mountPath: /var/lib/rclone-cache  # Path where cache volume will be mounted in container
 
 ## Reference to one or more secrets to be used when pulling images


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR adds support for mounting a separate volume for the rclone cache directory in the helm chart. This feature enables users to:

- Mount faster storage (e.g., local SSD, NVMe) for rclone cache to improve performance
- Use host path mounting in Talos/PVE environments where the cache folder needs to be on a separate drive
- Use CSI volumes for cache storage when faster storage is available via other CSI drivers

The implementation adds configuration options to the helm chart that allow users to specify either a hostPath or PVC for the cache directory, which is then mounted into the rclone container.

**Which issue(s) this PR fixes**:

Fixes #39

**Special notes for your reviewer**:

- The feature is disabled by default (`node.cache.enabled: false`) to maintain backward compatibility
- The cache mount path defaults to `/var/lib/rclone-cache` but can be customized
- Users need to specify `cache_dir` in their volume attributes to use the mounted cache directory
- Documentation has been added to README.md with examples for both use cases

**Does this PR introduce a user-facing change?**:

```release-note
Added support for mounting a separate volume for rclone cache directory. Users can now configure cache storage using either hostPath via helm chart values. See README for configuration examples.
```