### PR TITLE
add secret permissions in Cluster Role

### DIFF
--- a/charts/templates/rbac-csi-rclone.yaml
+++ b/charts/templates/rbac-csi-rclone.yaml
@@ -44,6 +44,9 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/base/rbac-csi-rclone.yaml
+++ b/deploy/base/rbac-csi-rclone.yaml
@@ -41,6 +41,9 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
 ---
 
 kind: ClusterRoleBinding


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Adds secrets read permissions to the CSI controller RBAC roles in both Helm charts and deploy manifests. This allows the CSI driver to access rclone configuration stored in Kubernetes secrets.

**Which issue(s) this PR fixes**:

Fixes #48

**Special notes for your reviewer**:

Added the following permission to controller/provisioner ClusterRoles:
- `apiGroups: [""]`
- `resources: ["secrets"]`
- `verbs: ["get"]`

This mirrors the RBAC configuration used in other CSI drivers like csi-driver-nfs.

**Does this PR introduce a user-facing change?**:

Add secrets read permission to CSI controller RBAC role to enable access to rclone configuration secrets.