### PR TITLE
chore(deps): bump rclone to v1.72.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,9 @@ require (
 	github.com/container-storage-interface/spec v1.12.0
 	github.com/kubernetes-csi/csi-lib-utils v0.23.0
 	github.com/prometheus/client_golang v1.23.2
-	github.com/rclone/rclone v1.72.0
+	github.com/rclone/rclone v1.72.1
 	github.com/stretchr/testify v1.11.1
 	github.com/unknwon/goconfig v1.0.0
-	golang.org/x/net v0.47.0
 	golang.org/x/sys v0.38.0
 	google.golang.org/grpc v1.76.0
 	google.golang.org/protobuf v1.36.10
@@ -211,6 +210,7 @@ require (
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546 // indirect
+	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/oauth2 v0.33.0 // indirect
 	golang.org/x/sync v0.18.0 // indirect
 	golang.org/x/term v0.37.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -514,8 +514,8 @@ github.com/putdotio/go-putio/putio v0.0.0-20200123120452-16d982cac2b8 h1:Y258uzX
 github.com/putdotio/go-putio/putio v0.0.0-20200123120452-16d982cac2b8/go.mod h1:bSJjRokAHHOhA+XFxplld8w2R/dXLH7Z3BZ532vhFwU=
 github.com/quic-go/quic-go v0.53.0 h1:QHX46sISpG2S03dPeZBgVIZp8dGagIaiu2FiVYvpCZI=
 github.com/quic-go/quic-go v0.53.0/go.mod h1:e68ZEaCdyviluZmy44P6Iey98v/Wfz6HCjQEm+l8zTY=
-github.com/rclone/rclone v1.72.0 h1:E7VfZRah6mGIOqz9HZm918COZ+VXWYGwafYfmnngRrA=
-github.com/rclone/rclone v1.72.0/go.mod h1:QjmSgz98CjQZZJhROIeYHYjpN5kN7rTA+jtChj/+3Do=
+github.com/rclone/rclone v1.72.1 h1:Cc/NshKd3/TP3CC0cx9Jg9nTLG8YQ8yLYMTm6Z/LdHk=
+github.com/rclone/rclone v1.72.1/go.mod h1:QjmSgz98CjQZZJhROIeYHYjpN5kN7rTA+jtChj/+3Do=
 github.com/relvacode/iso8601 v1.7.0 h1:BXy+V60stMP6cpswc+a93Mq3e65PfXCgDFfhvNNGrdo=
 github.com/relvacode/iso8601 v1.7.0/go.mod h1:FlNp+jz+TXpyRqgmM7tnzHHzBnz776kmAH2h3sZCn0I=
 github.com/rfjakob/eme v1.1.2 h1:SxziR8msSOElPayZNFfQw4Tjx/Sbaeeh3eRvrHVMUs4=

--- a/vendor/github.com/rclone/rclone/backend/googlecloudstorage/googlecloudstorage.go
+++ b/vendor/github.com/rclone/rclone/backend/googlecloudstorage/googlecloudstorage.go
@@ -346,9 +346,26 @@ can't check the size and hash but the file contents will be decompressed.
 			Advanced: true,
 			Default:  false,
 		}, {
-			Name:     "endpoint",
-			Help:     "Endpoint for the service.\n\nLeave blank normally.",
+			Name: "endpoint",
+			Help: `Custom endpoint for the storage API. Leave blank to use the provider default.
+
+When using a custom endpoint that includes a subpath (e.g. example.org/custom/endpoint),
+the subpath will be ignored during upload operations due to a limitation in the
+underlying Google API Go client library.
+Download and listing operations will work correctly with the full endpoint path.
+If you require subpath support for uploads, avoid using subpaths in your custom
+endpoint configuration.`,
 			Advanced: true,
+			Examples: []fs.OptionExample{{
+				Value: "storage.example.org",
+				Help:  "Specify a custom endpoint",
+			}, {
+				Value: "storage.example.org:4443",
+				Help:  "Specifying a custom endpoint with port",
+			}, {
+				Value: "storage.example.org:4443/gcs/api",
+				Help:  "Specifying a subpath, see the note, uploads won't use the custom path!",
+			}},
 		}, {
 			Name:     config.ConfigEncoding,
 			Help:     config.ConfigEncodingHelp,

--- a/vendor/github.com/rclone/rclone/backend/s3/provider/Selectel.yaml
+++ b/vendor/github.com/rclone/rclone/backend/s3/provider/Selectel.yaml
@@ -2,7 +2,17 @@ name: Selectel
 description: Selectel Object Storage
 region:
   ru-1: St. Petersburg
+  ru-3: St. Petersburg
+  ru-7: Moscow
+  gis-1: Moscow
+  kz-1: Kazakhstan
+  uz-2: Uzbekistan
 endpoint:
-  s3.ru-1.storage.selcloud.ru: Saint Petersburg
+  s3.ru-1.storage.selcloud.ru: St. Petersburg
+  s3.ru-3.storage.selcloud.ru: St. Petersburg
+  s3.ru-7.storage.selcloud.ru: Moscow
+  s3.gis-1.storage.selcloud.ru: Moscow
+  s3.kz-1.storage.selcloud.ru: Kazakhstan
+  s3.uz-2.storage.selcloud.ru: Uzbekistan
 quirks:
   list_url_encode: false

--- a/vendor/github.com/rclone/rclone/fs/config/crypt.go
+++ b/vendor/github.com/rclone/rclone/fs/config/crypt.go
@@ -77,8 +77,9 @@ func Decrypt(b io.ReadSeeker) (io.Reader, error) {
 		if strings.HasPrefix(l, "RCLONE_ENCRYPT_V") {
 			return nil, errors.New("unsupported configuration encryption - update rclone for support")
 		}
+		// Restore non-seekable plain-text stream to its original state
 		if _, err := b.Seek(0, io.SeekStart); err != nil {
-			return nil, err
+			return io.MultiReader(strings.NewReader(l+"\n"), r), nil
 		}
 		return b, nil
 	}

--- a/vendor/github.com/rclone/rclone/fs/log/log.go
+++ b/vendor/github.com/rclone/rclone/fs/log/log.go
@@ -209,7 +209,7 @@ func InitLogging() {
 	// Log file output
 	if Opt.File != "" {
 		var w io.Writer
-		if Opt.MaxSize == 0 {
+		if Opt.MaxSize < 0 {
 			// No log rotation - just open the file as normal
 			// We'll capture tracebacks like this too.
 			f, err := os.OpenFile(Opt.File, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0640)

--- a/vendor/github.com/rclone/rclone/fs/log/slog.go
+++ b/vendor/github.com/rclone/rclone/fs/log/slog.go
@@ -310,6 +310,10 @@ func (h *OutputHandler) jsonLog(ctx context.Context, buf *bytes.Buffer, r slog.R
 	r.AddAttrs(
 		slog.String("source", getCaller(2)),
 	)
+	// Add PID if requested
+	if h.format&logFormatPid != 0 {
+		r.AddAttrs(slog.Int("pid", os.Getpid()))
+	}
 	h.mu.Lock()
 	err = h.jsonHandler.Handle(ctx, r)
 	if err == nil {

--- a/vendor/github.com/rclone/rclone/fs/versiontag.go
+++ b/vendor/github.com/rclone/rclone/fs/versiontag.go
@@ -1,4 +1,4 @@
 package fs
 
 // VersionTag of rclone
-var VersionTag = "v1.72.0"
+var VersionTag = "v1.72.1"

--- a/vendor/github.com/rclone/rclone/lib/transform/transform.md
+++ b/vendor/github.com/rclone/rclone/lib/transform/transform.md
@@ -218,12 +218,12 @@ rclone convmv "stories/The Quick Brown Fox!.txt" --name-transform "all,command=e
 
 ```console
 rclone convmv "stories/The Quick Brown Fox!" --name-transform "date=-{YYYYMMDD}"
-// Output: stories/The Quick Brown Fox!-20251121
+// Output: stories/The Quick Brown Fox!-20251210
 ```
 
 ```console
 rclone convmv "stories/The Quick Brown Fox!" --name-transform "date=-{macfriendlytime}"
-// Output: stories/The Quick Brown Fox!-2025-11-21 0508PM
+// Output: stories/The Quick Brown Fox!-2025-12-10 1253PM
 ```
 
 ```console

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -874,7 +874,7 @@ github.com/prometheus/procfs/internal/util
 # github.com/putdotio/go-putio/putio v0.0.0-20200123120452-16d982cac2b8
 ## explicit; go 1.13
 github.com/putdotio/go-putio/putio
-# github.com/rclone/rclone v1.72.0
+# github.com/rclone/rclone v1.72.1
 ## explicit; go 1.24.4
 github.com/rclone/rclone/backend/alias
 github.com/rclone/rclone/backend/all


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:
Bump rclone to v1.72.1.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
