### PR TITLE
fix: disable VFS reuse to prevent context canceled errors

### DIFF
--- a/patches/vfs-disable-reuse.patch
+++ b/patches/vfs-disable-reuse.patch
@@ -1,0 +1,27 @@
+--- vendor/github.com/rclone/rclone/vfs/vfs.go	2026-04-08 07:57:22
++++ vendor/github.com/rclone/rclone/vfs/vfs.go	2026-04-08 07:57:38
+@@ -215,18 +215,15 @@
+ 	// Fill out anything else
+ 	vfs.Opt.Init()
+ 
+-	// Find a VFS with the same name and options and return it if possible
++	// Do not reuse active VFS instances. In a CSI driver each mount has its
++	// own cancellable context whose lifetime is tied to the mount. Reusing a
++	// VFS binds newer mounts to older contexts; when the older mount is
++	// unpublished and its context cancelled, the shared VFS breaks (e.g.
++	// OAuth token refresh fails with "context canceled").
++	// See: https://github.com/veloxpack/csi-driver-rclone/issues/69
+ 	activeMu.Lock()
+ 	defer activeMu.Unlock()
+ 	configName := fs.ConfigString(f)
+-	for _, activeVFS := range active[configName] {
+-		if vfs.Opt == activeVFS.Opt {
+-			fs.Debugf(f, "Reusing VFS from active cache")
+-			activeVFS.inUse.Add(1)
+-			return activeVFS
+-		}
+-	}
+-	// Put the VFS into the active cache
+ 	active[configName] = append(active[configName], vfs)
+ 
+ 	// Create root directory

--- a/vendor/github.com/rclone/rclone/vfs/vfs.go
+++ b/vendor/github.com/rclone/rclone/vfs/vfs.go
@@ -215,18 +215,15 @@ func New(f fs.Fs, opt *vfscommon.Options) *VFS {
 	// Fill out anything else
 	vfs.Opt.Init()
 
-	// Find a VFS with the same name and options and return it if possible
+	// Do not reuse active VFS instances. In a CSI driver each mount has its
+	// own cancellable context whose lifetime is tied to the mount. Reusing a
+	// VFS binds newer mounts to older contexts; when the older mount is
+	// unpublished and its context cancelled, the shared VFS breaks (e.g.
+	// OAuth token refresh fails with "context canceled").
+	// See: https://github.com/veloxpack/csi-driver-rclone/issues/69
 	activeMu.Lock()
 	defer activeMu.Unlock()
 	configName := fs.ConfigString(f)
-	for _, activeVFS := range active[configName] {
-		if vfs.Opt == activeVFS.Opt {
-			fs.Debugf(f, "Reusing VFS from active cache")
-			activeVFS.inUse.Add(1)
-			return activeVFS
-		}
-	}
-	// Put the VFS into the active cache
 	active[configName] = append(active[configName], vfs)
 
 	// Create root directory


### PR DESCRIPTION
## Summary
- Bumps rclone from v1.73.0 to v1.73.3
- Adds vendor patch to disable VFS active cache reuse, preventing "context canceled" errors when overlapping mounts share the same remote

## Problem
Rclone's VFS layer reuses active instances for identical remotes/options. In a CSI driver, each mount has its own cancellable context. When a VFS is reused, the newer mount inherits the older mount's `fs.Fs` and its context. Unpublishing the older mount cancels that shared context, breaking OAuth token refresh for the still-active mount.

This is an upstream rclone issue — the VFS reuse optimization is unsafe when mounts have independent lifecycles within the same process.

## Fix
Vendor patch (`patches/vfs-disable-reuse.patch`) removes the VFS active cache lookup in `vfs.New()`, ensuring each mount gets its own independent VFS instance.

Fixes #69

## Test plan
- [ ] Deploy with Google Drive backend (or any OAuth-based remote)
- [ ] Mount a PVC in pod A
- [ ] Start pod B mounting the same PVC before pod A is unpublished
- [ ] Unpublish pod A
- [ ] Verify pod B continues to work, including after token refresh